### PR TITLE
Add basic canvas app with build and GitHub Pages setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # tetris
+
 A Simple Tetris Game
+
+## Development
+
+1. Install dependencies (none currently but sets up scripts):
+   ```bash
+   npm install
+   ```
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+   The site will be available at http://localhost:3000.
+
+## Build
+
+Build the static files to the `dist` directory:
+```bash
+npm run build
+```
+
+## Deployment
+
+This project is configured to deploy to GitHub Pages using GitHub Actions. On every push to `main`, the site is built and published to the `gh-pages` environment.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tetris</title>
+  <link rel="stylesheet" href="./src/css/main.css" />
+</head>
+<body>
+  <canvas id="game" width="300" height="600"></canvas>
+  <script type="module" src="./src/js/main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "tetris",
+  "version": "1.0.0",
+  "description": "A Simple Tetris Game",
+  "main": "index.js",
+  "scripts": {
+    "dev": "node server.js",
+    "build": "rm -rf dist && mkdir dist && cp index.html dist/ && cp -R src dist/",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  const requestPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(__dirname, requestPath);
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = {
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.css': 'text/css'
+  }[ext] || 'text/plain';
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,0 +1,12 @@
+body {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: #f0f0f0;
+}
+
+canvas {
+  border: 1px solid #000;
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,0 +1,12 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+function draw() {
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = 'red';
+  ctx.fillRect(50, 50, 100, 100);
+}
+
+draw();


### PR DESCRIPTION
## Summary
- Add `index.html` with canvas element and module script
- Implement simple frame rendering and styling
- Add npm scripts and GitHub Pages deployment workflow

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689afbc10558832cac8b97dbbb3bc1b9