### PR TITLE
Add localStorage-backed leaderboard modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,12 @@
     <button id="pause">Pause</button>
     <button id="sound-toggle">Mute</button>
   </div>
+  <div id="leaderboard-modal">
+    <h2>Leaderboard</h2>
+    <ol id="leaderboard-list"></ol>
+    <button id="clear-leaderboard">Clear</button>
+    <button id="close-leaderboard">Close</button>
+  </div>
   <script type="module" src="./src/js/main.js"></script>
 </body>
 </html>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -33,3 +33,26 @@ canvas {
 #sound-toggle {
   display: none;
 }
+
+#leaderboard-modal {
+  display: none;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #fff;
+  border: 1px solid #000;
+  padding: 10px;
+  z-index: 100;
+  max-width: 80vmin;
+  font-family: sans-serif;
+}
+
+#leaderboard-modal.show {
+  display: block;
+}
+
+#leaderboard-modal ol {
+  padding-left: 20px;
+  margin: 0;
+}

--- a/src/js/leaderboard.js
+++ b/src/js/leaderboard.js
@@ -1,0 +1,95 @@
+const STORAGE_KEY = 'tetrisLeaderboard';
+const MAX_ENTRIES = 10;
+const MAX_STORAGE_SIZE = 50000; // characters
+
+function load() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw || raw.length > MAX_STORAGE_SIZE) {
+      return [];
+    }
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    return data;
+  } catch {
+    return [];
+  }
+}
+
+function save(entries) {
+  try {
+    const raw = JSON.stringify(entries);
+    if (raw.length > MAX_STORAGE_SIZE) {
+      return;
+    }
+    localStorage.setItem(STORAGE_KEY, raw);
+  } catch {
+    // ignore
+  }
+}
+
+export function addEntry(name, score) {
+  const entries = load();
+  entries.push({ name, score, date: new Date().toISOString() });
+  entries.sort((a, b) => b.score - a.score);
+  if (entries.length > MAX_ENTRIES) {
+    entries.length = MAX_ENTRIES;
+  }
+  save(entries);
+}
+
+export function getEntries(limit = MAX_ENTRIES) {
+  const entries = load();
+  entries.sort((a, b) => b.score - a.score);
+  return entries.slice(0, limit);
+}
+
+export function clear() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function renderLeaderboard(limit = MAX_ENTRIES) {
+  const list = document.getElementById('leaderboard-list');
+  if (!list) return;
+  const entries = getEntries(limit);
+  list.innerHTML = '';
+  entries.forEach((entry) => {
+    const li = document.createElement('li');
+    const date = new Date(entry.date).toLocaleDateString();
+    li.textContent = `${entry.name} - ${entry.score} (${date})`;
+    list.appendChild(li);
+  });
+}
+
+export function showLeaderboard(limit = MAX_ENTRIES) {
+  renderLeaderboard(limit);
+  const modal = document.getElementById('leaderboard-modal');
+  if (modal) {
+    modal.classList.add('show');
+  }
+}
+
+export function hideLeaderboard() {
+  const modal = document.getElementById('leaderboard-modal');
+  if (modal) {
+    modal.classList.remove('show');
+  }
+}
+
+export function setup() {
+  const closeBtn = document.getElementById('close-leaderboard');
+  const clearBtn = document.getElementById('clear-leaderboard');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', hideLeaderboard);
+  }
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      clear();
+      renderLeaderboard();
+    });
+  }
+}
+
+export { MAX_ENTRIES };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,7 @@
 import Board from './board.js';
 import { randomPiece } from './piece.js';
 import Score from './score.js';
+import { addEntry, showLeaderboard, setup as setupLeaderboard } from './leaderboard.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -32,6 +33,7 @@ const hud = document.getElementById('hud');
 const startBtn = document.getElementById('start');
 const pauseBtn = document.getElementById('pause');
 const soundToggle = document.getElementById('sound-toggle');
+setupLeaderboard();
 
 startBtn.addEventListener('click', startGame);
 pauseBtn.addEventListener('click', pauseGame);
@@ -147,6 +149,10 @@ function mergeAndSpawn() {
   }
   currentPiece = randomPiece();
   if (collide(board, currentPiece)) {
+    const finalScore = score.score;
+    const name = prompt('Enter your name') || 'Anonymous';
+    addEntry(name, finalScore);
+    showLeaderboard();
     board.reset();
     score.reset();
     dropInterval = baseDropInterval;


### PR DESCRIPTION
## Summary
- Add persistent leaderboard module that stores top scores in localStorage with size validation
- Prompt for player name on game over, save the entry, and show a modal with rankings
- Include styling and controls to clear or close the leaderboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b10417508832cb854234c1fa75f78