### PR TITLE
Add analytics tracking hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+src/js/config.js

--- a/README.md
+++ b/README.md
@@ -24,3 +24,19 @@ npm run build
 ## Deployment
 
 This project is configured to deploy to GitHub Pages using GitHub Actions. On every push to `main`, the site is built and published to the `gh-pages` environment.
+
+## Analytics
+
+Basic analytics hooks are available through `src/js/analytics.js`. The `track(eventName, data)` function logs game events such as game start, game over, line clear, and level up.
+
+To use a real analytics provider:
+
+1. Create a `src/js/config.js` file (ignored by Git) exporting your tracking key:
+
+   ```js
+   export const TRACKING_KEY = 'your-key-here';
+   ```
+
+2. Replace the `console.log` in `src/js/analytics.js` with calls to your analytics service (e.g., Google Analytics, Mixpanel).
+
+By default, a dummy key is used and events are simply logged to the console.

--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -1,0 +1,22 @@
+let trackingKey = 'dummy-key';
+
+import('./config.js')
+  .then((mod) => {
+    if (mod.TRACKING_KEY) {
+      trackingKey = mod.TRACKING_KEY;
+    }
+  })
+  .catch(() => {
+    // use dummy key if config.js is missing
+  });
+
+export function track(eventName, data = {}) {
+  const payload = {
+    key: trackingKey,
+    event: eventName,
+    data,
+    timestamp: Date.now(),
+  };
+  // Placeholder: replace console.log with real analytics provider
+  console.log('Tracking event', payload);
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -2,6 +2,7 @@ import Board from './board.js';
 import { randomPiece } from './piece.js';
 import Score from './score.js';
 import { addEntry, showLeaderboard, setup as setupLeaderboard } from './leaderboard.js';
+import { track } from './analytics.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -142,14 +143,17 @@ function mergeAndSpawn() {
   const lines = board.clearLines();
   if (lines) {
     playSfx('line');
+    track('line_clear', { lines });
   }
   const leveledUp = score.addLines(lines);
   if (leveledUp) {
     dropInterval = Math.max(100, baseDropInterval - score.level * 100);
+    track('level_up', { level: score.level });
   }
   currentPiece = randomPiece();
   if (collide(board, currentPiece)) {
     const finalScore = score.score;
+    track('game_over', { score: finalScore });
     const name = prompt('Enter your name') || 'Anonymous';
     addEntry(name, finalScore);
     showLeaderboard();
@@ -263,6 +267,7 @@ function startGame() {
   if (!isRunning) {
     isRunning = true;
     lastTime = 0;
+    track('game_start');
     update();
   }
 }


### PR DESCRIPTION
## Summary
- add analytics module with dummy tracking key fallback
- track game lifecycle events in main.js
- document analytics setup and ignore local config file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b22791748832c928244572900c0b0