### PR TITLE
Add PWA support and asset optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,38 @@
-# tetris
+# Tetris
 
-A Simple Tetris Game
+A browser-based Tetris clone with offline support.
 
-## Development
+## Features
+- Classic Tetris gameplay on HTML5 canvas.
+- Achievements and daily challenge modes.
+- Local leaderboard.
+- Installable Progressive Web App (PWA) with offline caching.
+- Basic analytics hooks.
 
-1. Install dependencies (none currently but sets up scripts):
+## Development Setup
+1. Install dependencies:
    ```bash
    npm install
    ```
-2. Run the development server:
+2. Start the development server:
    ```bash
    npm run dev
    ```
-   The site will be available at http://localhost:3000.
+   The app runs at http://localhost:3000.
+3. Run tests:
+   ```bash
+   npm test
+   ```
+4. Build optimized static files:
+   ```bash
+   npm run build
+   ```
+   Output is generated in the `dist` directory.
 
-## Build
-
-Build the static files to the `dist` directory:
-```bash
-npm run build
-```
+## Contribution Guidelines
+1. Fork the repository and create a branch for your change.
+2. Install dependencies and ensure `npm test` and `npm run build` complete without errors.
+3. Submit a pull request describing your changes.
 
 ## Deployment
-
-This project is configured to deploy to GitHub Pages using GitHub Actions. On every push to `main`, the site is built and published to the `gh-pages` environment.
-
-## Analytics
-
-Basic analytics hooks are available through `src/js/analytics.js`. The `track(eventName, data)` function logs game events such as game start, game over, line clear, and level up.
-
-To use a real analytics provider:
-
-1. Create a `src/js/config.js` file (ignored by Git) exporting your tracking key:
-
-   ```js
-   export const TRACKING_KEY = 'your-key-here';
-   ```
-
-2. Replace the `console.log` in `src/js/analytics.js` with calls to your analytics service (e.g., Google Analytics, Mixpanel).
-
-By default, a dummy key is used and events are simply logged to the console.
+The project is configured for GitHub Pages deployment via GitHub Actions. Pushes to `main` trigger a build and publish the contents of `dist` to the `gh-pages` environment.

--- a/build.js
+++ b/build.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const { minify } = require('terser');
+const csso = require('csso');
+
+const root = __dirname;
+const srcDir = path.join(root, 'src');
+const distDir = path.join(root, 'dist');
+
+fs.rmSync(distDir, { recursive: true, force: true });
+fs.mkdirSync(distDir, { recursive: true });
+
+['index.html', 'manifest.json', 'service-worker.js', 'icon.svg'].forEach((file) => {
+  fs.copyFileSync(path.join(root, file), path.join(distDir, file));
+});
+
+const copyAndMinifyCss = () => {
+  const cssSrcDir = path.join(srcDir, 'css');
+  const cssDistDir = path.join(distDir, 'src', 'css');
+  fs.mkdirSync(cssDistDir, { recursive: true });
+  fs.readdirSync(cssSrcDir).forEach((file) => {
+    const css = fs.readFileSync(path.join(cssSrcDir, file), 'utf8');
+    const minified = csso.minify(css).css;
+    fs.writeFileSync(path.join(cssDistDir, file), minified);
+  });
+};
+
+const copyAndMinifyJs = async () => {
+  const jsSrcDir = path.join(srcDir, 'js');
+  const jsDistDir = path.join(distDir, 'src', 'js');
+  fs.mkdirSync(jsDistDir, { recursive: true });
+  for (const file of fs.readdirSync(jsSrcDir)) {
+    const js = fs.readFileSync(path.join(jsSrcDir, file), 'utf8');
+    const result = await minify(js);
+    fs.writeFileSync(path.join(jsDistDir, file), result.code);
+  }
+};
+
+const build = async () => {
+  copyAndMinifyCss();
+  await copyAndMinifyJs();
+};
+
+build();

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#000"/>
+  <path d="M96 96h320v96h-96v224h-128V192h-96z" fill="#fff"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tetris</title>
+  <meta name="theme-color" content="#000000" />
+  <link rel="manifest" href="manifest.json" />
   <link rel="stylesheet" href="./src/css/main.css" />
 </head>
 <body>
@@ -28,5 +30,12 @@
     <button id="close-leaderboard">Close</button>
   </div>
   <script type="module" src="./src/js/main.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('service-worker.js');
+      });
+    }
+  </script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "short_name": "Tetris",
+  "name": "Tetris Game",
+  "icons": [
+    {
+      "src": "icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "512x512"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,180 @@
+{
+  "name": "tetris",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tetris",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "csso": "^5.0.5",
+        "terser": "^5.17.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.43.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
+      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.14.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,11 +5,15 @@
   "main": "index.js",
   "scripts": {
     "dev": "node server.js",
-    "build": "rm -rf dist && mkdir dist && cp index.html dist/ && cp -R src dist/",
+    "build": "node build.js",
     "test": "echo \"No tests\""
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "csso": "^5.0.5",
+    "terser": "^5.17.0"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -11,7 +11,9 @@ const server = http.createServer((req, res) => {
   const contentType = {
     '.html': 'text/html',
     '.js': 'text/javascript',
-    '.css': 'text/css'
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.svg': 'image/svg+xml'
   }[ext] || 'text/plain';
 
   fs.readFile(filePath, (err, content) => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,27 @@
+const CACHE_NAME = 'tetris-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './manifest.json',
+  './icon.svg',
+  './src/css/main.css',
+  './src/js/achievements.js',
+  './src/js/analytics.js',
+  './src/js/board.js',
+  './src/js/leaderboard.js',
+  './src/js/main.js',
+  './src/js/piece.js',
+  './src/js/score.js'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- enable offline installable PWA via new manifest and service worker
- minify JavaScript and CSS with new build script
- document features, development setup and contribution guidelines

## Testing
- `npm test`
- `npm run build`
- `find dist -maxdepth 3 -type f -print`
- `wc -l src/js/main.js dist/src/js/main.js`
- `wc -l src/css/main.css dist/src/css/main.css`


------
https://chatgpt.com/codex/tasks/task_e_689b5f74af90832c801e9f60036abca2