### PR TITLE
feat: add responsive layout for game UI

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,34 +1,32 @@
 html,
 body {
   height: 100%;
+  margin: 0;
+  padding: 0;
   overflow: hidden;
-  margin: 0;
-  padding: 0;
   background: #f0f0f0;
-}
-
-#game-container,
-canvas {
-  width: 100vw;
-  height: 100vh;
-  margin: 0;
-  padding: 0;
 }
 
 #game-container {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  height: 100%;
 }
 
 canvas {
   display: block;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
   border: 1px solid #000;
 }
 
 #hud {
-  position: absolute;
-  top: 10px;
-  left: 10px;
-  margin: 0;
+  order: -1;
+  margin: 10px 0;
   color: #000;
   background: rgba(255, 255, 255, 0.8);
   padding: 4px 8px;
@@ -37,17 +35,38 @@ canvas {
 }
 
 #controls {
-  position: absolute;
-  bottom: 10px;
-  left: 50%;
-  transform: translateX(-50%);
+  order: 1;
   display: flex;
   gap: 5px;
-  margin: 0;
+  margin: 10px 0;
 }
 
 #sound-toggle {
   display: none;
+}
+
+#side-panel {
+  order: 2;
+  margin: 10px 0;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #000;
+  padding: 10px;
+  font-family: sans-serif;
+  max-width: 200px;
+}
+
+#side-panel ul {
+  list-style: none;
+  padding-left: 15px;
+  margin: 0 0 10px 0;
+}
+
+#side-panel li.locked {
+  opacity: 0.5;
+}
+
+#side-panel li.unlocked {
+  font-weight: bold;
 }
 
 #leaderboard-modal {
@@ -73,27 +92,42 @@ canvas {
   margin: 0;
 }
 
-#side-panel {
-  position: fixed;
-  top: 10px;
-  right: 10px;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid #000;
-  padding: 10px;
-  font-family: sans-serif;
-  max-width: 200px;
+@media (min-width: 768px) {
+  #game-container {
+    display: grid;
+    grid-template-columns: auto 200px;
+    grid-template-rows: auto 1fr auto;
+    gap: 20px;
+    height: 100vh;
+  }
+
+  canvas {
+    width: 300px;
+    height: 600px;
+    grid-column: 1;
+    grid-row: 1 / span 2;
+  }
+
+  #hud {
+    order: 0;
+    margin: 0;
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  #side-panel {
+    order: 0;
+    margin: 0;
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  #controls {
+    order: 0;
+    grid-column: 1 / 3;
+    grid-row: 3;
+    margin: 0;
+    justify-content: center;
+  }
 }
 
-#side-panel ul {
-  list-style: none;
-  padding-left: 15px;
-  margin: 0 0 10px 0;
-}
-
-#side-panel li.locked {
-  opacity: 0.5;
-}
-
-#side-panel li.unlocked {
-  font-weight: bold;
-}


### PR DESCRIPTION
## Summary
- add mobile-first flex column layout stacking HUD and controls around the canvas
- apply desktop media query with grid to position HUD and side panel beside the canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c71da34c0832ca13caf9ff9196169