### PR TITLE
Add touch controls for mobile play

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,12 @@
       <button id="pause">Pause</button>
       <button id="sound-toggle">Mute</button>
     </div>
+    <div id="touch-controls">
+      <button data-action="left">Left</button>
+      <button data-action="right">Right</button>
+      <button data-action="rotate">Rotate</button>
+      <button data-action="down">Down</button>
+    </div>
     <div id="side-panel">
       <h2>Achievements</h2>
       <ul id="achievement-list"></ul>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -41,6 +41,20 @@ canvas {
   margin: 10px 0;
 }
 
+#touch-controls {
+  display: none;
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  gap: 10px;
+}
+
+#touch-controls button {
+  padding: 10px;
+  font-size: 1rem;
+}
+
 #sound-toggle {
   display: none;
 }
@@ -90,6 +104,13 @@ canvas {
 #leaderboard-modal ol {
   padding-left: 20px;
   margin: 0;
+}
+
+@media (max-width: 767px) {
+  #touch-controls {
+    display: flex;
+    justify-content: center;
+  }
 }
 
 @media (min-width: 768px) {

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1,0 +1,25 @@
+export function setupTouchControls({ left, right, rotate, down }) {
+  const container = document.getElementById('touch-controls');
+  if (!container || window.getComputedStyle(container).display === 'none') {
+    return;
+  }
+
+  const bind = (action, handler) => {
+    const btn = container.querySelector(`[data-action="${action}"]`);
+    if (btn) {
+      btn.addEventListener(
+        'touchstart',
+        (e) => {
+          e.preventDefault();
+          handler();
+        },
+        { passive: false }
+      );
+    }
+  };
+
+  bind('left', left);
+  bind('right', right);
+  bind('rotate', rotate);
+  bind('down', down);
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -12,6 +12,7 @@ import {
   getDailySeed,
   updateDailyStatus,
 } from './achievements.js';
+import { setupTouchControls } from './controls.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
@@ -274,6 +275,13 @@ document.addEventListener('keydown', (event) => {
     default:
       break;
   }
+});
+
+setupTouchControls({
+  left: () => movePiece(-1, 0, true),
+  right: () => movePiece(1, 0, true),
+  rotate: () => rotatePiece(true),
+  down: () => movePiece(0, 1, true),
 });
 
 function hardDrop() {


### PR DESCRIPTION
## Summary
- Add mobile-specific touch control buttons and styling
- Map touch events to existing game movement functions
- Keep keyboard controls when touch controls are hidden

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7d6d7f90832ca8785d88b0f46345